### PR TITLE
Fixed Bug in Predicate Binding

### DIFF
--- a/src/perl/aaron/TruthTrees/logic/LogicalOperator.java
+++ b/src/perl/aaron/TruthTrees/logic/LogicalOperator.java
@@ -29,7 +29,7 @@ public abstract class LogicalOperator extends Statement implements Decomposable 
 					Binding curBinding = statements.get(i).determineBinding(unboundOp.statements.get(i));
 					if (curBinding == null)
 					{
-						System.out.println("Invalid binding between\n\t" + statements.get(i).toString() + "\n\t" + unbound.toString());
+						System.out.println("Invalid binding between\n\t" + statements.get(i).toString() + "\n\t" + unboundOp.statements.get(i).toString());
 						return null;
 					}
 					if (b == null || b.equals(Binding.EMPTY_BINDING))

--- a/src/perl/aaron/TruthTrees/logic/Predicate.java
+++ b/src/perl/aaron/TruthTrees/logic/Predicate.java
@@ -84,7 +84,7 @@ public class Predicate extends Statement {
 					{
 						b = curBinding;
 					}
-					else if ((b != curBinding && !b.equals(Binding.EMPTY_BINDING)) || curBinding == null)
+					else if (!b.equals(curBinding) && !curBinding.equals(Binding.EMPTY_BINDING))
 					{
 						return null;
 					}


### PR DESCRIPTION
Previously, when binding two multivariable predicates, if a nonempty binding was created from a pair of the predicates arguments before the last then the binding would always fail. This pull request fixes that bug as well as a confusing error message that was output when a binding failed for two logical operators of the same type.